### PR TITLE
Fix: multiple export defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Test helper to simulate browsers back and forward buttons in acceptance tests.
 
 ## Installation
 * `ember install ember-cli-browser-navigation-button-test-helper`
-* Add `import './browser-navigation-buttons';` to `tests/helpers/start-app.js`.
+* Add `import registerBrowserNavigationButtons from './browser-navigation-buttons';` and a call of `registerBrowserNavigationButtons();` before `application.injectTestHelpers();` in `tests/helpers/start-app.js`.
 * Add `backButton`, `forwardButton` and `setupBrowserNavigationButtons` as predef in `tests/.jshintrc`.
 
 ## Quickstart

--- a/test-support/helpers/browser-navigation-buttons.js
+++ b/test-support/helpers/browser-navigation-buttons.js
@@ -1,22 +1,22 @@
 import Ember from 'ember';
 
-export default Ember.Test.registerAsyncHelper('backButton', function(app) {
+const backButton = function(app) {
   const history = app.__container__.lookup('service:history');
   Ember.assert('setupBrowserNavigationButtons must be called before `backButton` could be used.', history);
   Ember.run(() => {
     history.goBack();
   });
-});
+};
 
-export default Ember.Test.registerAsyncHelper('forwardButton', function(app) {
+const forwardButton = function(app) {
   const history = app.__container__.lookup('service:history');
   Ember.assert('setupBrowserNavigationButtons must be called before `forwardButton` could be used.', history);
   Ember.run(() => {
     history.goForward();
   });
-});
+};
 
-export default Ember.Test.registerHelper('setupBrowserNavigationButtons', function(app) {
+const setupBrowserNavigationButtons = function(app) {
   const router = app.__container__.lookup('router:main');
   const history = Ember.Service.create({
     addHistory() {
@@ -46,4 +46,10 @@ export default Ember.Test.registerHelper('setupBrowserNavigationButtons', functi
   });
   app.register('service:history', history, { instantiate: false });
   Ember.addObserver(router, 'currentPath', history, 'addHistory');
-});
+};
+
+export default function() {
+  Ember.Test.registerAsyncHelper('backButton', backButton);
+  Ember.Test.registerAsyncHelper('forwardButton', forwardButton);
+  Ember.Test.registerHelper('setupBrowserNavigationButtons', setupBrowserNavigationButtons);
+}

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
-import './browser-navigation-buttons';
+import registerBrowserNavigationButtons from './browser-navigation-buttons';
 
 export default function startApp(attrs) {
   let application;
@@ -12,6 +12,9 @@ export default function startApp(attrs) {
   Ember.run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
+
+    registerBrowserNavigationButtons();
+
     application.injectTestHelpers();
   });
 


### PR DESCRIPTION
`browser-navigation-button` test helper now exports a function which registers test helpers.
Therefore you have to update `tests/helpers/start-app.js` in your application.