### PR TITLE
Support dynamic segments and queryParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ There is an usage example [in this acceptance test](https://github.com/jelhan/em
 Known limitations
 ------------------------------------------------------------------------------
 
-Query params are not supported yet.
-
 Support for old-style acceptance tests (before RFC #232 and #268) was dropped in `v0.1.0`. You could use `v0.0.5` if you need to support them, but this one does not support Ember 3.x.
 
 

--- a/tests/acceptance/browser-navigation-buttons-test.js
+++ b/tests/acceptance/browser-navigation-buttons-test.js
@@ -59,7 +59,7 @@ module('Acceptance | test helpers', function(hooks) {
     assert.equal(currentURL(), '/dynamic/item-id');
     assert.equal(currentRouteName(), 'dynamic');
 
-    await click('a');
+    await click('a.uses-id-only');
     assert.equal(currentURL(), '/dynamic/another-item-id');
     assert.equal(currentRouteName(), 'dynamic');
 
@@ -70,5 +70,34 @@ module('Acceptance | test helpers', function(hooks) {
     await forwardButton();
     assert.equal(currentURL(), '/dynamic/another-item-id');
     assert.equal(currentRouteName(), 'dynamic');
+  });
+
+  test('handle query string parameters', async function(assert) {
+    setupBrowserNavigationButtons();
+
+    await visit('/');
+    await click('a.uses-query-params');
+    assert.equal(currentURL(), '/dynamic/yet-another-item-id?a=1&b=2&c=3');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await click('a.uses-id-and-query-params');
+    assert.equal(currentURL(), '/dynamic/a-different-item-id?a=9&b=8&c=7');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await click('a.uses-id-only');
+    assert.equal(currentURL(), '/dynamic/another-item-id');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await backButton();
+    assert.equal(currentURL(), '/dynamic/a-different-item-id?a=9&b=8&c=7');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await backButton();
+    assert.equal(currentURL(), '/dynamic/yet-another-item-id?a=1&b=2&c=3');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await backButton();
+    assert.equal(currentURL(), '/');
+    assert.equal(currentRouteName(), 'index');
   });
 });

--- a/tests/acceptance/browser-navigation-buttons-test.js
+++ b/tests/acceptance/browser-navigation-buttons-test.js
@@ -50,4 +50,25 @@ module('Acceptance | test helpers', function(hooks) {
     await backButton();
     assert.equal(currentRouteName(), 'index');
   });
+
+  test('handles dynamic segments', async function(assert) {
+    setupBrowserNavigationButtons();
+
+    await visit('/');
+    await click('a.uses-dynamic-segment');
+    assert.equal(currentURL(), '/dynamic/item-id');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await click('a');
+    assert.equal(currentURL(), '/dynamic/another-item-id');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await backButton();
+    assert.equal(currentURL(), '/dynamic/item-id');
+    assert.equal(currentRouteName(), 'dynamic');
+
+    await forwardButton();
+    assert.equal(currentURL(), '/dynamic/another-item-id');
+    assert.equal(currentRouteName(), 'dynamic');
+  });
 });

--- a/tests/dummy/app/controllers/dynamic.js
+++ b/tests/dummy/app/controllers/dynamic.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['a', 'b', 'c']
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('foo');
   this.route('bar');
   this.route('uses-loading-substate');
+  this.route('dynamic', { path: '/dynamic/:id' });
 });
 
 export default Router;

--- a/tests/dummy/app/templates/dynamic.hbs
+++ b/tests/dummy/app/templates/dynamic.hbs
@@ -1,0 +1,1 @@
+{{#link-to "dynamic" "another-item-id"}}go to route which uses a dynamic segment{{/link-to}}

--- a/tests/dummy/app/templates/dynamic.hbs
+++ b/tests/dummy/app/templates/dynamic.hbs
@@ -1,1 +1,2 @@
-{{#link-to "dynamic" "another-item-id"}}go to route which uses a dynamic segment{{/link-to}}
+{{#link-to "dynamic" "another-item-id" class="uses-id-only"}}go to route which uses a dynamic segment{{/link-to}}
+{{#link-to "dynamic" "a-different-item-id" (query-params a=9 b=8 c=7) class="uses-id-and-query-params"}}go to route which uses a dynamic segment{{/link-to}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,3 +1,4 @@
 {{#link-to "foo" class="foo"}}go to foo{{/link-to}}
 {{#link-to "uses-loading-substate" class="uses-loading-substate"}}go to route which uses a loading substate{{/link-to}}
 {{#link-to "dynamic" "item-id" class="uses-dynamic-segment"}}go to route which uses a dynamic segment{{/link-to}}
+{{#link-to "dynamic" "yet-another-item-id" (query-params a=1 b=2 c=3) class="uses-query-params"}}go to route which uses query string parameters{{/link-to}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,2 +1,3 @@
 {{#link-to "foo" class="foo"}}go to foo{{/link-to}}
 {{#link-to "uses-loading-substate" class="uses-loading-substate"}}go to route which uses a loading substate{{/link-to}}
+{{#link-to "dynamic" "item-id" class="uses-dynamic-segment"}}go to route which uses a dynamic segment{{/link-to}}


### PR DESCRIPTION
It wasn't working properly for dynamic segments, so I've changed it so the URL is stashed instead of the route path. I've noticed that this also makes it work for queryParams so I added a test for both scenarios.