### PR TITLE
run Ember 3.28 scenario in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           - ember-lts-3.8
           - ember-lts-3.16
           - ember-lts-3.24
+          - ember-lts-3.28
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Scenario for Ember 3.28 was failing when adding CI in #34. But it seems that the dependency upgrades have fixed that.