### PR TITLE
Support Ember v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-lts-3.28
+          - ember-release
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Support for Ember v4 was fixed before in several independent merge requests. This only updates CI configuration to run the Ember Try scenario for Ember v4 (`ember-release`).